### PR TITLE
Small edits to zonal.calculations and read.in.and.process.vectors

### DIFF
--- a/FunctionLibraries/SummarizeChange_functions.R
+++ b/FunctionLibraries/SummarizeChange_functions.R
@@ -157,7 +157,7 @@ read.in.and.process.vectors<-function(crop.poly,rstrs,sumPly,sumPlyNm){
 
 	cr.poly<-vect(crop.poly)
 	#returns layers with both projected to first argument's CRS
-	crop_poly_proj<-check.crs.match(rasters$before,cr.poly)
+	crop_poly_proj<-check.crs.match(rstrs$before,cr.poly)
 	print(paste(crop.poly," read in and processed.",sep=""))
 
 

--- a/FunctionLibraries/SummarizeChange_functions.R
+++ b/FunctionLibraries/SummarizeChange_functions.R
@@ -180,11 +180,11 @@ read.in.and.process.vectors<-function(crop.poly,rstrs,sumPly,sumPlyNm){
 
 #This function actually does the zonal calculations for raster pixels that fall within
 #the entire spatial summary area (e.g. HUC)
-zonal.calculations<-function(rsters,rwVec,prepVec){
+zonal.calculations<-function(rsters,prepVec){
 
 	 #----------- Zonal calcs for entire summary areas ------------#
 	 #this takes a long time
-	 summaryzonal.time<- system.time(zonal.stats.summarypoly<-zonal(rsters$diff,rwVec$sumPoly,fun="mean",as.polygons=TRUE,na.rm=TRUE) )
+	 summaryzonal.time<- system.time(zonal.stats.summarypoly<-zonal(rsters$diff,prepVec$sumPoly,fun="mean",as.polygons=TRUE,na.rm=TRUE) )
 	print("Zonal stats calculated for whole summary unit (raw averages)")
 	 print(summaryzonal.time/60)
 


### PR DESCRIPTION
Changed "rasters" to "rstrs" in read.in.and.process.vectors function. 

Eliminated "rwVec" argument from zonal.calculations function and changed later mention of "rwVec" to "prepVec" to match new calls. 